### PR TITLE
Use H2 DB instead of MySQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -70,6 +65,11 @@
 		<dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/eu/printingtrackerv2/configuration/SpringSecurityConfig.java
+++ b/src/main/java/eu/printingtrackerv2/configuration/SpringSecurityConfig.java
@@ -36,7 +36,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()        //.anyRequest().permitAll(); -> as if to disable the security
-                .antMatchers("/", "/register", "/bootstrap/**", "/jquery/**", "/text/javascript/**").permitAll()
+                .antMatchers("/", "/h2/**", "/register", "/bootstrap/**", "/jquery/**", "/text/javascript/**").permitAll()
                 //.antMatchers("/user/**").hasRole("USER")
                 .antMatchers("/user/**").access("hasRole('ADMIN') OR hasRole('USER')")
                 .antMatchers("/admin/**").hasRole("ADMIN")
@@ -60,6 +60,8 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                 .logout().logoutSuccessUrl("/login?logout").permitAll()
             .and()
                 .exceptionHandling().accessDeniedPage("/unauthorized")
+            .and()
+                .headers().frameOptions().sameOrigin()
             .and()
                 .csrf().disable();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,20 @@
-#Data Source Properties
-spring.datasource.driverClassName=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/printing_tracker?useSSL=false&createDatabaseIfNotExist=true
+# DB, use H2 with embedded database in the current folder
+spring.datasource.url=jdbc:h2:./printingtracker
 spring.datasource.username=root
 spring.datasource.password=1234
 
-#JPA Properties
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
-spring.jpa.properties.hibernate.format_sql=TRUE
-spring.jpa.hibernate.ddl-auto=update
+# JPA: Show SQL fancy, formatted syntax.
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Update the DB if needed, destroys the previous data!
+spring.jpa.hibernate.ddl-auto=create
+
+# H2 DB configuration
+# Opens a Web-Base SQL client on /h2 alias.
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2
+spring.h2.console.settings.web-allow-others=true
 
 
 ###Logging Levels

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,12 @@
+-- DB propagation script
+-- This script will be automatically executed to create initial DB values, in case
+-- when the spring.jpa.hibernate.ddl-auto is 'create'
+
+-- create default roles
+insert into roles (id, authority) values (1, 'ROLE_ADMIN');
+insert into roles (id, authority) values (2, 'ROLE_USER');
+-- create default admin user with 'admin' password
+insert into users (id, is_account_non_expired, is_account_non_locked, is_credentials_non_expired, is_enabled, password, username) values (1, true, true, true, true, '$2a$10$kSIa7De9pPwVICOL2SQmfuM0gbwlcMxFag/C82fZsT0u/suGwye6K', 'admin@admin');
+-- provide 'admin' user 'admin' role
+insert into users_roles (user_id, role_id) values (1, 1);
+


### PR DESCRIPTION
This commit enables the usage of H2 database, instead of MySQL. H2 will run embedded into the Spring Boot application and you don't need to install any other SQL server in addition to the application.

While this is great for development and showcase H2 shouldn't be used when the application is deployed in production.
